### PR TITLE
Add network configuration to autoinstall.

### DIFF
--- a/packer/ubuntu-server/http/user-data
+++ b/packer/ubuntu-server/http/user-data
@@ -34,13 +34,27 @@ autoinstall:
     password: '$6$BY7tlmmh0KhsyCdF$mqL6Ud5FS645ylyOUT.qoim/ZcHrfLdE6vgDqAabDGyoj7LCV4Kpskj8POMmf7MmIcpVho0xc12rdstjjjW100'
     hostname: ubuntu-server
 
-  ssh:
-    allow-pw: yes
-    install-server: true
+  # Uncomment the block below to force interactive configuration on first run.  
+  # interactive-sections:
+  #    - network  
 
   locale: en_US
   keyboard: 
     layout: us
+
+  network:
+    version: 2
+    renderer: networkd
+    ethernets:
+      all-en:
+        match:
+          name: "en*"
+        dhcp4: true
+        dhcp-identifier: mac  
+
+  ssh:
+    allow-pw: yes
+    install-server: true
 
   # Subiquity will, by default, configure a partition layout using LVM.
   storage:


### PR DESCRIPTION
The VM refused to connect to a network when stood up in a Proxmox environment. As it turns out, failing to give it an explicit allocation for its ethernet resources will cause it to just pretend they don't exist. 🙃 

This addition automatically adds DHCP connectivity to all ethernet interfaces attached to this VM via netplan. The system's MAC address is used for the negotiation of leases, which should prevent any problems with cloned machine IDs. I've also added in a sample block that will force interactive network configuration if we choose to use it in the future.