### PR TITLE
feat: Add GitHub Actions workflow for building dibbs-vm on trigger ♍ 

### DIFF
--- a/.github/workflows/dibbsVm.yml
+++ b/.github/workflows/dibbsVm.yml
@@ -1,0 +1,35 @@
+name: Build dibbs-vm
+run-name: Build dibbs-vm triggered by @${{ github.actor }}
+
+on:
+  repository_dispatch:
+    types: [trigger-workflow]
+    
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract service and version
+        id: extract
+        run: |
+          service="${{ github.event.client_payload.service }}"
+          version="${{ github.event.client_payload.version }}"
+          echo "::set-output name=service::$service"
+          echo "::set-output name=version::$version"
+
+      - name: Build dibbs-vm for dibbs-ecr-viewer
+        if: ${{ steps.extract.outputs.service == 'dibbs-ecr-viewer' }}
+        run: |
+          echo "Building dibbs-vm version ${{ steps.extract.outputs.version }} for ${{ steps.extract.outputs.service }}"
+          
+      - name: Build dibbs-vm for dibbs-query-connector
+        if: ${{ steps.extract.outputs.service == 'dibbs-query-connector' }}
+        run: |
+          echo "Building dibbs-vm version ${{ steps.extract.outputs.version }} for ${{ steps.extract.outputs.service }}"


### PR DESCRIPTION
## Changes Proposed 

- #21 
- Initial PR to verify the workflows are connected properly.
- This PR introduces a new GitHub actions workflow named `dibbsVM.yml`. This is a target workflow to kick off a VM build for the services `dibbs-ecr-viewer` or `dibbs-query-connector`. 

## Additional Information 

- This workflow is triggered by a repository dispatch with the type `trigger-workflow`. The event's payload is expected to contain the service name and version number to be built.
- The VM build is only executed if the event payload specifies either the `dibbs-ecr-viewer` or `dibbs-query-connector` services.