### PR TITLE
Add AWS and Azure source block to Packer config

### DIFF
--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -61,7 +61,13 @@ jobs:
         with:
             creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-      
+      - name: Set AWS & Azure Credentials
+        run: |
+              export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
+              export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
+              export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
+              export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
+              echo "Azure credentials set"
       
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
@@ -97,6 +103,14 @@ jobs:
         with:
            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       
+      - name: Set Azure Credentials
+        run: |
+                 export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
+                 export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
+                 export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                 export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
+                 echo "Azure credentials set"
+
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:
@@ -133,6 +147,14 @@ jobs:
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
+      - name: Set AWS & Azure Credentials
+        run: |
+                export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
+                export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
+                export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
+                echo "Azure credentials set"
+                
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -55,6 +55,11 @@ jobs:
         service: ['dibbs-ecr-viewer', 'dibbs-query-connector']
     steps:
       - uses: actions/checkout@v4
+
+      - name: login into Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }} 
       
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
@@ -75,6 +80,7 @@ jobs:
       - name: Run `packer build`
         working-directory: ./packer/ubuntu-server
         run: packer build --var dibbs_service=${{ matrix.service }} --var dibbs_version=main .
+
 
   packer_build_repository_dispatch:
     if: github.event_name == 'repository_dispatch'

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -56,10 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: login into Azure
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }} 
+      
       
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
@@ -120,6 +117,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: login into Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }} 
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -68,6 +68,15 @@ jobs:
         uses: azure/login@v2
         with:
             creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+          
+      - name: Set up Azure authentication for Packer
+        run: |
+              echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
+              echo "ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}" >> $GITHUB_ENV
+              echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+              echo "ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
+        shell: bash 
+
 
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
@@ -110,7 +119,14 @@ jobs:
         uses: azure/login@v2
         with:
            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-      
+      - name: Set up Azure authentication for Packer
+        run: |
+              echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
+              echo "ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}" >> $GITHUB_ENV
+              echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+              echo "ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
+        shell: bash 
+
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:
@@ -155,7 +171,14 @@ jobs:
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-
+      - name: Set up Azure authentication for Packer
+        run: |
+            echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
+            echo "ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}" >> $GITHUB_ENV
+            echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
+            echo "ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
+        shell: bash
+        
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -57,12 +57,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      #- name: Configure AWS Credentials
-        #uses: aws-actions/configure-aws-credentials@v2
-        #with:
-          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          #aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Authenticate to Azure
         uses: azure/login@v2
@@ -107,18 +107,19 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      #- name: Configure AWS Credentials
-        #uses: aws-actions/configure-aws-credentials@v2
-        #with:
-          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          #aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
 
       - name: login into Azure
         uses: azure/login@v2
         with:
            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+           
       - name: Set up Azure authentication for Packer
         run: |
               echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV
@@ -159,12 +160,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      #- name: Configure AWS Credentials
-        #uses: aws-actions/configure-aws-credentials@v2
-        #with:
-          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          #aws-region: ${{ secrets.AWS_REGION }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: login into Azure
         uses: azure/login@v2

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -116,11 +116,11 @@ jobs:
           - provisioners: ${{ inputs.provisioners }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: login into Azure
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }} 
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -57,26 +57,18 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      #- name: Configure AWS Credentials
+        #uses: aws-actions/configure-aws-credentials@v2
+        #with:
+          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          #aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Authenticate to Azure
         uses: azure/login@v2
         with:
             creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-      - name: Set AWS & Azure Credentials
-        run: |
-              export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
-              export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
-              export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
-              export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
-              echo "Azure credentials set"
-      
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:
@@ -106,12 +98,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      #- name: Configure AWS Credentials
+        #uses: aws-actions/configure-aws-credentials@v2
+        #with:
+          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          #aws-region: ${{ secrets.AWS_REGION }}
 
 
       - name: login into Azure
@@ -119,14 +111,6 @@ jobs:
         with:
            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       
-      - name: Set Azure Credentials
-        run: |
-                 export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
-                 export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
-                 export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
-                 export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
-                 echo "Azure credentials set"
-
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:
@@ -159,25 +143,18 @@ jobs:
       - uses: actions/checkout@v4
 
       # AWS Authentication
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      #- name: Configure AWS Credentials
+        #uses: aws-actions/configure-aws-credentials@v2
+        #with:
+          #aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          #aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          #aws-region: ${{ secrets.AWS_REGION }}
 
       - name: login into Azure
         uses: azure/login@v2
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-      - name: Set AWS & Azure Credentials
-        run: |
-                export ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}
-                export ARM_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }}
-                export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
-                export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
-                echo "Azure credentials set"
 
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -56,6 +56,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # AWS Authentication
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Authenticate to Azure
         uses: azure/login@v2
         with:
@@ -96,6 +104,14 @@ jobs:
     needs: [ docs_build ]
     steps:
       - uses: actions/checkout@v4
+
+      # AWS Authentication
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
 
       - name: login into Azure
@@ -142,6 +158,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # AWS Authentication
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: login into Azure
         uses: azure/login@v2
         with:
@@ -154,7 +178,7 @@ jobs:
                 export ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}
                 export ARM_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}
                 echo "Azure credentials set"
-                
+
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -56,6 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Authenticate to Azure
+        uses: azure/login@v2
+        with:
+            creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
       
       
       - name: Set up Packer
@@ -85,6 +90,12 @@ jobs:
     needs: [ docs_build ]
     steps:
       - uses: actions/checkout@v4
+
+
+      - name: login into Azure
+        uses: azure/login@v2
+        with:
+           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
@@ -121,6 +132,7 @@ jobs:
         uses: azure/login@v2
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+
       - name: Set up Packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232
         with:

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -8,15 +8,52 @@
 # 6. Updates the package list again to include the Docker repository.
 # 7. Installs Docker packages including docker-ce, docker-ce-cli, containerd.io, docker-buildx-plugin, and docker-compose-plugin.
 
+#!/bin/bash
+
+# Set default sudo behavior (empty means no sudo)
+USE_SUDO="${USE_SUDO:-}"
+
 # Install Docker
-echo "post-install"
-apt update
-install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-chmod a+r /etc/apt/keyrings/docker.asc
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-  tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt update
-apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+echo "Starting post-install configuration..."
+
+# Ensure package lists are updated
+$USE_SUDO apt-get update -y
+
+# Determine the build type based on environment variable
+if [ "$BUILD_TYPE" == "aws" ]; then
+    echo "Running AWS-specific Docker installation..."
+
+    # Create keyring directory with proper permissions
+    $USE_SUDO install -m 0755 -d /etc/apt/keyrings
+
+    # Download and store Docker's GPG key
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | $USE_SUDO tee /etc/apt/keyrings/docker.asc > /dev/null
+
+    # Fix permissions for the key
+    $USE_SUDO chmod a+r /etc/apt/keyrings/docker.asc
+
+    # Add Docker repository for AWS
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | $USE_SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+else
+    echo "Running QEMU/Hypervisor-specific Docker installation..."
+
+    # Create keyring directory with proper permissions
+    install -m 0755 -d /etc/apt/keyrings
+
+    # Download Docker GPG key for QEMU/Hypervisors
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+
+    # Add Docker repository for QEMU/Hypervisors
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+fi
+
+# Update package lists again
+$USE_SUDO apt-get update -y
+
+# Install Docker and dependencies
+$USE_SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+echo "Docker installation complete!"
+
+

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -13,6 +13,9 @@
 # Set default sudo behavior (empty means no sudo)
 USE_SUDO="${USE_SUDO:-}"
 
+# Set default sudo behavior (empty means no sudo)
+USE_SUDO="${USE_SUDO:-}"
+
 # Install Docker
 echo "Starting post-install configuration..."
 
@@ -55,5 +58,8 @@ $USE_SUDO apt-get update -y
 $USE_SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 echo "Docker installation complete!"
+<<<<<<< HEAD
 
 
+=======
+>>>>>>> e63d5be (Refactor post-install script to use sudo as a configurable variable)

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -12,54 +12,39 @@
 
 # Set default sudo behavior (empty means no sudo)
 USE_SUDO="${USE_SUDO:-}"
-
 # Set default sudo behavior (empty means no sudo)
 USE_SUDO="${USE_SUDO:-}"
-
 # Install Docker
 echo "Starting post-install configuration..."
-
 # Ensure package lists are updated
 $USE_SUDO apt-get update -y
 
 # Determine the build type based on environment variable
 if [ "$BUILD_TYPE" == "aws" ]; then
     echo "Running AWS-specific Docker installation..."
-
     # Create keyring directory with proper permissions
     $USE_SUDO install -m 0755 -d /etc/apt/keyrings
-
     # Download and store Docker's GPG key
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | $USE_SUDO tee /etc/apt/keyrings/docker.asc > /dev/null
-
     # Fix permissions for the key
     $USE_SUDO chmod a+r /etc/apt/keyrings/docker.asc
-
     # Add Docker repository for AWS
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | $USE_SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
-
 else
     echo "Running QEMU/Hypervisor-specific Docker installation..."
-
     # Create keyring directory with proper permissions
     install -m 0755 -d /etc/apt/keyrings
-
     # Download Docker GPG key for QEMU/Hypervisors
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-
     # Add Docker repository for QEMU/Hypervisors
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 fi
-
 # Update package lists again
 $USE_SUDO apt-get update -y
-
 # Install Docker and dependencies
 $USE_SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
 echo "Docker installation complete!"
-<<<<<<< HEAD
 
 
-=======
->>>>>>> e63d5be (Refactor post-install script to use sudo as a configurable variable)
+
+

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -35,6 +35,23 @@ packer {
   }
 }
 
+<<<<<<< HEAD
+=======
+
+variable "aws_region" {
+  description = "AWS region to build the AMI"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_instance_type" {
+  description = "AWS instance type for the build"
+  type        = string
+  default     = "t3.medium"
+}
+
+
+>>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
 source "qemu" "iso" {
   vm_name = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}.raw"
   # Uncomment this block to use a basic Ubuntu 24.04 cloud image
@@ -108,10 +125,24 @@ build {
     "source.amazon-ebs.aws-ami"
   ]
 
+<<<<<<< HEAD
   # AWS-Specific Post-Install Provisioner
   provisioner "shell" {
     only   = ["amazon-ebs.aws-ami"]
     script = "scripts/post-install.sh"
+=======
+  # AWS-Specific Post-Install Provisioner (Runs Only on AWS)
+  provisioner "shell" {
+    only   = ["amazon-ebs.aws-ami"]
+    script = "scripts/aws-post-install.sh"
+  }
+
+  # Common Provisioner for Both QEMU and AWS
+  provisioner "shell" {
+    scripts = [
+      "scripts/provision.sh"
+    ]
+>>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
     environment_vars = [
       "DIBBS_SERVICE=${var.dibbs_service}",
       "DIBBS_VERSION=${var.dibbs_version}",
@@ -120,6 +151,7 @@ build {
     ]
     execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
+<<<<<<< HEAD
 
   # QEMU/Hypervisor-Specific Post-Install Provisioner
   provisioner "shell" {
@@ -161,4 +193,6 @@ build {
     source      = "./scripts/apt-updates.sh.home"
     destination = "~/apt-updates.sh"
   }
+=======
+>>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
 }

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -121,6 +121,9 @@ source "azure-arm" "azure-image" {
   os_type                           = "Linux"
   ssh_username                      = "ubuntu"
 
+   # disable Managed Identity
+  use_managed_identity              = false
+
 }
 
 

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -35,16 +35,11 @@ packer {
   }
 }
 
-<<<<<<< HEAD
-=======
 
-
->>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
 source "qemu" "iso" {
   vm_name = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}.raw"
   # Uncomment this block to use a basic Ubuntu 24.04 cloud image
   # iso_url              = "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
-<<<<<<< HEAD
   iso_url          = "http://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
   iso_checksum     = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
   disk_image       = false
@@ -55,39 +50,11 @@ source "qemu" "iso" {
   format           = "raw"
   net_device       = "virtio-net"
   boot_wait        = "3s"
-=======
-  # iso_checksum         = "sha256:28d2f9df3ac0d24440eaf6998507df3405142cf94a55e1f90802c78e43d2d9df"
-  # disk_image           = true
-
-  # Uncomment this block to configure Ubuntu 24.04 server from scratch
-  iso_url      = "http://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
-  iso_checksum = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
-  disk_image   = false
-
-  memory           = 4096
-  output_directory = "build/${var.dibbs_service}-${var.dibbs_version}"
-  //accelerator          = "hvf"
-  disk_size      = "8000M"
-  disk_interface = "virtio"
-  format         = "raw"
-  net_device     = "virtio-net"
-  boot_wait      = "3s"
-  #boot_command         = [
-  #  "e<wait>",
-  #  "<down><down><down><end>",
-  #  " autoinstall ds=\"nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/\" ",
-  #  "<f10>"
-  #  ]
->>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   boot_command = [
     "c<wait>linux /casper/vmlinuz --- autoinstall 'ds=nocloud;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/'<enter><wait>",
     "initrd /casper/initrd<enter><wait><wait>",
     "boot<enter><wait>"
   ]
-<<<<<<< HEAD
-=======
-  # boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
->>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   http_directory   = "http"
   shutdown_command = "echo 'ubuntu' | sudo -S shutdown -P now"
   ssh_username     = "ubuntu"
@@ -142,17 +109,7 @@ build {
     "source.amazon-ebs.aws-ami"
   ]
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   # AWS-Specific Post-Install Provisioner
-  provisioner "shell" {
-    only   = ["amazon-ebs.aws-ami"]
-    script = "scripts/post-install.sh"
-=======
-  # AWS-Specific Post-Install Provisioner (Runs Only on AWS)
-=======
-  # AWS-Specific Post-Install Provisioner
->>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   provisioner "shell" {
     only   = ["amazon-ebs.aws-ami"]
     script = "scripts/post-install.sh"
@@ -164,38 +121,6 @@ build {
     ]
     execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
-
-  # QEMU/Hypervisor-Specific Post-Install Provisioner
-  provisioner "shell" {
-    only   = ["qemu.iso"]
-    script = "scripts/post-install.sh"
-    environment_vars = [
-      "DIBBS_SERVICE=${var.dibbs_service}",
-      "DIBBS_VERSION=${var.dibbs_version}",
-      "USE_SUDO=",
-      "BUILD_TYPE=qemu"
-    ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} bash '{{.Path}}'"
-  }
-
-  # Common Provisioner for Both QEMU and AWS
-  provisioner "shell" {
-    scripts = [
-      "scripts/provision.sh"
-    ]
->>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
-    environment_vars = [
-      "DIBBS_SERVICE=${var.dibbs_service}",
-      "DIBBS_VERSION=${var.dibbs_version}",
-<<<<<<< HEAD
-      "USE_SUDO=sudo",
-      "BUILD_TYPE=aws"
-=======
->>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
-    ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
-  }
-<<<<<<< HEAD
 
   # QEMU/Hypervisor-Specific Post-Install Provisioner
   provisioner "shell" {
@@ -222,7 +147,7 @@ build {
     execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
-  
+  # File Transfer Provisioners
   provisioner "file" {
     source      = "../../${var.dibbs_service}/${var.dibbs_service}-wizard.sh.home"
     destination = "~/${var.dibbs_service}-wizard.sh"
@@ -237,6 +162,4 @@ build {
     source      = "./scripts/apt-updates.sh.home"
     destination = "~/apt-updates.sh"
   }
-=======
->>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
 }

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -120,6 +120,9 @@ source "azure-arm" "azure-image" {
   managed_image_resource_group_name = "skylight-dibbs-vm1"
   os_type                           = "Linux"
   ssh_username                      = "ubuntu"
+
+   # Disable Managed Identity
+  use_managed_identity = false
 }
 
 

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -122,7 +122,7 @@ source "azure-arm" "azure-image" {
   ssh_username                      = "ubuntu"
 
    # disable Managed Identity
-  use_managed_identity              = false
+  #use_managed_identity              = false
 
 }
 

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -121,9 +121,6 @@ source "azure-arm" "azure-image" {
   os_type                           = "Linux"
   ssh_username                      = "ubuntu"
 
-   # disable Managed Identity
-  #use_managed_identity              = false
-
 }
 
 

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -121,8 +121,6 @@ source "azure-arm" "azure-image" {
   os_type                           = "Linux"
   ssh_username                      = "ubuntu"
 
-   # Disable Managed Identity
-  use_managed_identity = false
 }
 
 

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -38,24 +38,13 @@ packer {
 <<<<<<< HEAD
 =======
 
-variable "aws_region" {
-  description = "AWS region to build the AMI"
-  type        = string
-  default     = "us-east-1"
-}
-
-variable "aws_instance_type" {
-  description = "AWS instance type for the build"
-  type        = string
-  default     = "t3.medium"
-}
-
 
 >>>>>>> 4f9b5dd (updated AWS to use a unified provison.sh script)
 source "qemu" "iso" {
   vm_name = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}.raw"
   # Uncomment this block to use a basic Ubuntu 24.04 cloud image
   # iso_url              = "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+<<<<<<< HEAD
   iso_url          = "http://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
   iso_checksum     = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
   disk_image       = false
@@ -66,11 +55,39 @@ source "qemu" "iso" {
   format           = "raw"
   net_device       = "virtio-net"
   boot_wait        = "3s"
+=======
+  # iso_checksum         = "sha256:28d2f9df3ac0d24440eaf6998507df3405142cf94a55e1f90802c78e43d2d9df"
+  # disk_image           = true
+
+  # Uncomment this block to configure Ubuntu 24.04 server from scratch
+  iso_url      = "http://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
+  iso_checksum = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+  disk_image   = false
+
+  memory           = 4096
+  output_directory = "build/${var.dibbs_service}-${var.dibbs_version}"
+  //accelerator          = "hvf"
+  disk_size      = "8000M"
+  disk_interface = "virtio"
+  format         = "raw"
+  net_device     = "virtio-net"
+  boot_wait      = "3s"
+  #boot_command         = [
+  #  "e<wait>",
+  #  "<down><down><down><end>",
+  #  " autoinstall ds=\"nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/\" ",
+  #  "<f10>"
+  #  ]
+>>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   boot_command = [
     "c<wait>linux /casper/vmlinuz --- autoinstall 'ds=nocloud;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/'<enter><wait>",
     "initrd /casper/initrd<enter><wait><wait>",
     "boot<enter><wait>"
   ]
+<<<<<<< HEAD
+=======
+  # boot_command    = ["<wait>e<wait5>", "<down><wait><down><wait><down><wait2><end><wait5>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
+>>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   http_directory   = "http"
   shutdown_command = "echo 'ubuntu' | sudo -S shutdown -P now"
   ssh_username     = "ubuntu"
@@ -126,15 +143,39 @@ build {
   ]
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   # AWS-Specific Post-Install Provisioner
   provisioner "shell" {
     only   = ["amazon-ebs.aws-ami"]
     script = "scripts/post-install.sh"
 =======
   # AWS-Specific Post-Install Provisioner (Runs Only on AWS)
+=======
+  # AWS-Specific Post-Install Provisioner
+>>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
   provisioner "shell" {
     only   = ["amazon-ebs.aws-ami"]
-    script = "scripts/aws-post-install.sh"
+    script = "scripts/post-install.sh"
+    environment_vars = [
+      "DIBBS_SERVICE=${var.dibbs_service}",
+      "DIBBS_VERSION=${var.dibbs_version}",
+      "USE_SUDO=sudo",
+      "BUILD_TYPE=aws"
+    ]
+    execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+  }
+
+  # QEMU/Hypervisor-Specific Post-Install Provisioner
+  provisioner "shell" {
+    only   = ["qemu.iso"]
+    script = "scripts/post-install.sh"
+    environment_vars = [
+      "DIBBS_SERVICE=${var.dibbs_service}",
+      "DIBBS_VERSION=${var.dibbs_version}",
+      "USE_SUDO=",
+      "BUILD_TYPE=qemu"
+    ]
+    execute_command = "echo 'ubuntu' | {{.Vars}} bash '{{.Path}}'"
   }
 
   # Common Provisioner for Both QEMU and AWS
@@ -146,8 +187,11 @@ build {
     environment_vars = [
       "DIBBS_SERVICE=${var.dibbs_service}",
       "DIBBS_VERSION=${var.dibbs_version}",
+<<<<<<< HEAD
       "USE_SUDO=sudo",
       "BUILD_TYPE=aws"
+=======
+>>>>>>> 391e050 (Modified ubuntu.pkr.hcl to reflect new variables)
     ]
     execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -20,10 +20,6 @@ variable "dibbs_version" {
   type        = string
 }
 
-<<<<<<< HEAD
-=======
-
->>>>>>> bd5052a (Updated variables.pkr.hcl for improved parameterization with aws region and instance)
 variable "aws_region" {
   description = "AWS region to build the AMI"
   type        = string
@@ -31,10 +27,6 @@ variable "aws_region" {
 
 }
 
-<<<<<<< HEAD
-=======
-
->>>>>>> bd5052a (Updated variables.pkr.hcl for improved parameterization with aws region and instance)
 variable "aws_instance_type" {
   description = "AWS instance type for the build"
   type        = string

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -19,3 +19,17 @@ variable "dibbs_version" {
   description = "The version of the service to be built"
   type        = string
 }
+
+variable "aws_region" {
+  description = "AWS region to build the AMI"
+  type        = string
+  default     = "us-east-1"
+
+}
+
+variable "aws_instance_type" {
+  description = "AWS instance type for the build"
+  type        = string
+  default     = "t3.medium"
+
+}

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -33,3 +33,27 @@ variable "aws_instance_type" {
   default     = "t3.medium"
 
 }
+
+variable "subscription_id" {
+  description = "Azure Subscription ID"
+  type        = string
+  default     = env("ARM_SUBSCRIPTION_ID") # Automatically pulls from env
+}
+
+variable "client_id" {
+  description = "Azure Client ID"
+  type        = string
+  default     = env("ARM_CLIENT_ID")
+}
+
+variable "client_secret" {
+  description = "Azure Client Secret"
+  type        = string
+  default     = env("ARM_CLIENT_SECRET")
+}
+
+variable "tenant_id" {
+  description = "Azure Tenant ID"
+  type        = string
+  default     = env("ARM_TENANT_ID")
+}

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -20,6 +20,10 @@ variable "dibbs_version" {
   type        = string
 }
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> bd5052a (Updated variables.pkr.hcl for improved parameterization with aws region and instance)
 variable "aws_region" {
   description = "AWS region to build the AMI"
   type        = string
@@ -27,6 +31,10 @@ variable "aws_region" {
 
 }
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> bd5052a (Updated variables.pkr.hcl for improved parameterization with aws region and instance)
 variable "aws_instance_type" {
   description = "AWS instance type for the build"
   type        = string


### PR DESCRIPTION
 This PR includes and resolves #26 and #27 

## AWS 
- Refactoring `post-install script` to use sudo as a configurable variable for AWS build and 

- Updated the `ubuntu.pkr.hcl `config file to reflect changes made to `main `

- Removed `aws-post-install script` to maintain single source of `Post-install `script 

- Updated `packMachines.yml ` with AWS secrets to build AMI and deploy to Skylight's AWS Account via Github Actions





### Testing

Testing Instructions:

- Navigate to Actions
- Click on the `[pack virtual machine images](https://github.com/CDCgov/dibbs-vm/actions/workflows/packMachines.yml)`
- Run Workflow, then use `Emmanuel/Cloud-source` as Branch to test and build the AMI
-  This should successfully build the AMI 
- Log in to Skylight's AWS account 
- Navigate to the Ami section on the portal 
- You should see an AMI with the naming convention Ubuntu-2404-dibbs-ecr-viewer-main 


## AZURE 

**Summary**

- Added an Azure source block in `ubuntu.pkr.hcl `to maintain the `AMD64` architecture with the Ubuntu LTS AMI.

- Modified `variables.pkr.hcl` to include Azure credentials for authentication.

**Changes**

- Updated `ubuntu.pkr.hcl `to support Azure Image build.

- Added necessary variables for Azure deployment in `variables.pkr.hcl.`

- Updated `packMachines.yml ` with Azure secrets to build Image and deploy to Skylight Azure's Account via Github Actions 

## How to Test

- Navigate to Actions
- Click on the `[pack virtual machine images](https://github.com/CDCgov/dibbs-vm/actions/workflows/packMachines.yml)`
- Run Workflow, then use `Emmanuel/Cloud-source` as Branch to test and build the Azure image
-  This should successfully build the image
- Log in to Skylight's Azure account 
- Locate the resource group `skylight-dibbs-vm1`
- You should see an Azure image with the naming convention `Ubuntu-2404-dibbs-ecr-viewer-main `










