### PR TITLE
Update script 💠 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,4 +32,4 @@ packer validate --var dibbs_service="$service" --var dibbs_version="$version" .
 # Build the base image
 packer build --var dibbs_service="$service" --var dibbs_version="$version" .
 
-cd ../../ || exit
+cd - || exit

--- a/packer/ubuntu-server/scripts/apt-updates.sh.home
+++ b/packer/ubuntu-server/scripts/apt-updates.sh.home
@@ -19,6 +19,10 @@ set_defaults() {
   apt_clean=false
 }
 
+msg() {
+  echo -e "\e[1;32m$1\e[0m"
+}
+
 # if no arguments are passed, run the help message
 help() {
   echo "Usage: ./updates.sh [-u] [-d] [-a] [-c] [-h] OR [-udac]"
@@ -69,25 +73,24 @@ check_options() {
 # run the update, upgrade, autoremove, and clean commands
 run_update() {
   if [ "$apt_update" = true ]; then
-    echo -e "\e[1;32mUpdating package list...\e[0m"
+    msg "Updating package list..."
     sudo apt update -y
-    echo -e "\e[1;32mPackage list updated\e[0m"
+    msg "Package list updated"
   fi
   if [ "$apt_upgrade" = true ]; then
-    echo -e "\e[1;32mUpgrading installed packages...\e[0m"
+    msg "Upgrading installed packages..."
     sudo apt upgrade -y
-    echo -e "\e[1;32mInstalled packages upgraded\e[0m"
+    msg "Installed packages upgraded"
   fi
   if [ "$apt_autoremove" = true ]; then
-    echo -e "\e[1;32mRemoving unnecessary packages...\e[0m"
+    msg "Removing unnecessary packages..."
     sudo apt autoremove -y
-    echo -e "\e[1;32mUnnecessary packages removed\e[0m"
+    msg "Unnecessary packages removed"
   fi
   if [ "$apt_clean" = true ]; then
-    # retry the clean command if it can't get a lock
-    echo -e "\e[1;32mCleaning up the cache...\e[0m"
+    msg "Cleaning up the cache..."
     sudo apt clean
-    echo -e "\e[1;32mCache cleaned\e[0m"
+    msg "Cache cleaned up"
   fi
 }
 

--- a/packer/ubuntu-server/scripts/apt-updates.sh.home
+++ b/packer/ubuntu-server/scripts/apt-updates.sh.home
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# This script updates the Ubuntu server packages, applies security updates, performs system upgrades,
+# removes unnecessary packages, and cleans up the cache.
+#
+# Functions:
+#   set_defaults: Initializes default values for the script options.
+#   help: Displays the usage information and available options.
+#   check_options: Parses and validates the command-line options.
+#   run_update: Executes the update, upgrade, autoremove, and clean commands based on the provided options.
+
+set -e
+
+# This script updates the ubuntu server packages, security updates, system upgrades, removes unnecessary packages, and cleans up the cache.
+set_defaults() {
+  apt_update=false
+  apt_upgrade=false
+  apt_autoremove=false
+  apt_clean=false
+}
+
+# if no arguments are passed, run the help message
+help() {
+  echo "Usage: ./updates.sh [-u] [-d] [-a] [-c] [-h] OR [-udac]"
+  echo "Run all options: ./updates.sh -udac"
+  echo "Options:"
+  echo "  -u  Update the package list"
+  echo "  -d  Upgrade the installed packages"
+  echo "  -a  Remove unnecessary packages"
+  echo "  -c  Clean up the cache"
+  echo "  -h  Display this help message"
+  exit 1
+}
+
+check_options() {
+  if [ $# -eq 0 ]; then
+    help
+  fi
+  while getopts "udach" opt; do
+    case ${opt} in
+      u )
+        # set apt_update to true
+        apt_update=true
+        ;;
+      d )
+        # set apt_upgrade to true
+        apt_upgrade=true
+        ;;
+      a )
+        # set apt_autoremove to true
+        apt_autoremove=true
+        ;;
+      c )
+        # set apt_clean to true
+        apt_clean=true
+        ;;
+      # update this to run if no arguments are passed
+      h )
+        help
+        ;;
+      \? )
+        echo "Invalid option: $OPTARG"
+        ;;
+    esac
+  done
+  shift $((OPTIND -1))
+}
+
+# run the update, upgrade, autoremove, and clean commands
+run_update() {
+  if [ "$apt_update" = true ]; then
+    echo -e "\e[1;32mUpdating package list...\e[0m"
+    sudo apt update -y
+    echo -e "\e[1;32mPackage list updated\e[0m"
+  fi
+  if [ "$apt_upgrade" = true ]; then
+    echo -e "\e[1;32mUpgrading installed packages...\e[0m"
+    sudo apt upgrade -y
+    echo -e "\e[1;32mInstalled packages upgraded\e[0m"
+  fi
+  if [ "$apt_autoremove" = true ]; then
+    echo -e "\e[1;32mRemoving unnecessary packages...\e[0m"
+    sudo apt autoremove -y
+    echo -e "\e[1;32mUnnecessary packages removed\e[0m"
+  fi
+  if [ "$apt_clean" = true ]; then
+    # retry the clean command if it can't get a lock
+    echo -e "\e[1;32mCleaning up the cache...\e[0m"
+    sudo apt clean
+    echo -e "\e[1;32mCache cleaned\e[0m"
+  fi
+}
+
+set_defaults
+check_options "$@"
+run_update

--- a/packer/ubuntu-server/scripts/apt-updates.sh.home
+++ b/packer/ubuntu-server/scripts/apt-updates.sh.home
@@ -11,7 +11,6 @@
 
 set -e
 
-# This script updates the ubuntu server packages, security updates, system upgrades, removes unnecessary packages, and cleans up the cache.
 set_defaults() {
   apt_update=false
   apt_upgrade=false
@@ -23,7 +22,6 @@ msg() {
   echo -e "\e[1;32m$1\e[0m"
 }
 
-# if no arguments are passed, run the help message
 help() {
   echo "Usage: ./updates.sh [-u] [-d] [-a] [-c] [-h] OR [-udac]"
   echo "Run all options: ./updates.sh -udac"
@@ -37,28 +35,24 @@ help() {
 }
 
 check_options() {
+  # if no arguments are passed, run the help message
   if [ $# -eq 0 ]; then
     help
   fi
   while getopts "udach" opt; do
     case ${opt} in
       u )
-        # set apt_update to true
         apt_update=true
         ;;
       d )
-        # set apt_upgrade to true
         apt_upgrade=true
         ;;
       a )
-        # set apt_autoremove to true
         apt_autoremove=true
         ;;
       c )
-        # set apt_clean to true
         apt_clean=true
         ;;
-      # update this to run if no arguments are passed
       h )
         help
         ;;
@@ -70,8 +64,7 @@ check_options() {
   shift $((OPTIND -1))
 }
 
-# run the update, upgrade, autoremove, and clean commands
-run_update() {
+run_commands() {
   if [ "$apt_update" = true ]; then
     msg "Updating package list..."
     sudo apt update -y
@@ -96,4 +89,4 @@ run_update() {
 
 set_defaults
 check_options "$@"
-run_update
+run_commands

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -10,7 +10,7 @@
 
 # Install Docker
 echo "post-install"
-apt-get update
+apt update
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
@@ -18,5 +18,5 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update
-apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+apt update
+apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -92,4 +92,9 @@ build {
     destination = "~/hot-upgrade.sh"
   }
 
+  provisioner "file" {
+    source      = "./scripts/apt-updates.sh.home"
+    destination = "~/apt-updates.sh"
+  }
+
 }


### PR DESCRIPTION
## Changes Proposed 

- resolves #25 
- An additional script `apt-updates.sh.home` has been added. This script updates the Ubuntu server packages, applies security updates, performs system upgrades, removes unnecessary packages, and cleans the cache. Arguments gate all actions.
- The `post-install.sh` script was also adjusted, replacing `apt-get` commands with the more modern `apt` commands.

## Testing 
- Build the VM
- Launch the VM
- Run the apt-updates.sh script in the `$HOME` directory of the VM , `./apt-updates.sh -h` to get usage instructions.
- Run the updates you want by using the appropriate arguments.