### PR TITLE
Add security by default.

### DIFF
--- a/.github/workflows/packMachines.yml
+++ b/.github/workflows/packMachines.yml
@@ -83,8 +83,8 @@ jobs:
         with:
           version: 1.11.2
 
-      - name: Install QEMU
-        run: sudo apt-get update && sudo apt-get install -y qemu-system-x86
+      - name: Install Supporting Packages
+        run: sudo apt-get update && sudo apt-get install -y qemu-system-x86 openssl
 
       - name: Run `packer init`
         working-directory: ./packer/ubuntu-server

--- a/build.sh
+++ b/build.sh
@@ -48,10 +48,10 @@ echo "Password replaced in user-data file."
 packer init .
 
 # validate
-packer validate --var dibbs_service="$service" --var dibbs_version="$version" .
+packer validate --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" .
 
 # Build the base image
-packer build --var dibbs_service="$service" --var dibbs_version="$version" .
+packer build --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" .
 
 echo "Remember, to login, you need to use the password: $DIBBS_USER_PASSWORD"
 

--- a/build.sh
+++ b/build.sh
@@ -38,9 +38,9 @@ password_hash=$(openssl passwd -6 $DIBBS_USER_PASSWORD)
 
 # replace the password hash in the packer user-data file
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s|'{{password_hash}}'|'"$password_hash"'|" ./packer/ubuntu-server/http/user-data
+    sed -i '' "s|'{{password_hash}}'|'"$password_hash"'|" ./http/user-data
 else
-    sed -i "s|'{{password_hash}}'|'"$password_hash"'|" ./packer/ubuntu-server/http/user-data
+    sed -i "s|'{{password_hash}}'|'"$password_hash"'|" ./http/user-data
 fi
 echo "Password replaced in user-data file."
 

--- a/packer/ubuntu-server/http/user-data
+++ b/packer/ubuntu-server/http/user-data
@@ -27,12 +27,11 @@ autoinstall:
 
   identity:
     realname: ''
-    username: ubuntu
+    username: dibbs-user
     # A password hash is needed. `mkpasswd --method=SHA-512` can help.
     # mkpasswd can be found in the package 'whois'
-    # password -> ubuntu
-    password: '$6$BY7tlmmh0KhsyCdF$mqL6Ud5FS645ylyOUT.qoim/ZcHrfLdE6vgDqAabDGyoj7LCV4Kpskj8POMmf7MmIcpVho0xc12rdstjjjW100'
-    hostname: ubuntu-server
+    password: '{{password_hash}}'
+    hostname: dibbs-vm
 
   # Uncomment the block below to force interactive configuration on first run.  
   # interactive-sections:

--- a/packer/ubuntu-server/jails/jail.local
+++ b/packer/ubuntu-server/jails/jail.local
@@ -1,0 +1,34 @@
+[DEFAULT]
+
+# ignore localhost for Packer builds and other tools
+ignoreip = 127.0.0.1
+
+# clients that trigger a ban will be banned for the length
+# of time specified here
+bantime = 10m
+
+# these two fields set the evaluation window and number
+# of authentication attempts that trigger a ban
+findtime = 10m
+maxretry = 5
+
+# parameters for configuring email alerts when a client
+# triggers a ban
+destemail = root@localhost
+sender = root@<fq-hostname>
+mta = sendmail
+
+# ban & send an e-mail with whois report to the destemail
+# configured above.
+action_mw = %(action_)s
+            %(mta)s-whois[sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+action = $(action_)s
+
+
+[ssh]
+
+enabled  = true
+port     = ssh
+filter   = sshd
+logpath  = /var/log/auth.log
+maxretry = 5

--- a/packer/ubuntu-server/scripts/apt-updates.sh.home
+++ b/packer/ubuntu-server/scripts/apt-updates.sh.home
@@ -67,22 +67,22 @@ check_options() {
 run_commands() {
   if [ "$apt_update" = true ]; then
     msg "Updating package list..."
-    sudo apt update -y
+    sudo apt-get update -y
     msg "Package list updated"
   fi
   if [ "$apt_upgrade" = true ]; then
     msg "Upgrading installed packages..."
-    sudo apt upgrade -y
+    sudo apt-get upgrade -y
     msg "Installed packages upgraded"
   fi
   if [ "$apt_autoremove" = true ]; then
     msg "Removing unnecessary packages..."
-    sudo apt autoremove -y
+    sudo apt-get autoremove -y
     msg "Unnecessary packages removed"
   fi
   if [ "$apt_clean" = true ]; then
     msg "Cleaning up the cache..."
-    sudo apt clean
+    sudo apt-get clean
     msg "Cache cleaned up"
   fi
 }

--- a/packer/ubuntu-server/scripts/fail2ban.sh
+++ b/packer/ubuntu-server/scripts/fail2ban.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script configures and activates fail2ban on the configured VM.
+# 1. Update package lists and install fail2ban.
+# 2. Copies the provided jail.local file to the fail2ban configuration directory.
+# 3. Enables the fail2ban service to start on boot.
+# 4. Starts the fail2ban service for the first time.
+# 5. Checks the status of the fail2ban service to ensure it is running. Outputs the 
+#    status to the console for debugging purposes.
+# Install fail2ban
+sudo apt-get update && sudo apt-get install fail2ban -y
+sudo cp ~/jail.local /etc/fail2ban/jail.local
+sudo systemctl enable fail2ban
+sudo systemctl start fail2ban
+sudo systemctl status fail2ban

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -17,7 +17,7 @@ USE_SUDO="${USE_SUDO:-}"
 # Install Docker
 echo "Starting post-install configuration..."
 # Ensure package lists are updated
-$USE_SUDO apt-get update -y
+$USE_SUDO apt update
 
 # Determine the build type based on environment variable
 if [ "$BUILD_TYPE" == "aws" ]; then
@@ -40,9 +40,9 @@ else
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 fi
 # Update package lists again
-$USE_SUDO apt-get update -y
+$USE_SUDO apt update
 # Install Docker and dependencies
-$USE_SUDO apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+$USE_SUDO apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 echo "Docker installation complete!"
 
 

--- a/packer/ubuntu-server/scripts/post-install.sh
+++ b/packer/ubuntu-server/scripts/post-install.sh
@@ -17,7 +17,7 @@ USE_SUDO="${USE_SUDO:-}"
 # Install Docker
 echo "Starting post-install configuration..."
 # Ensure package lists are updated
-$USE_SUDO apt update
+$USE_SUDO apt-get update
 
 # Determine the build type based on environment variable
 if [ "$BUILD_TYPE" == "aws" ]; then
@@ -40,11 +40,7 @@ else
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 fi
 # Update package lists again
-$USE_SUDO apt update
+$USE_SUDO apt-get update
 # Install Docker and dependencies
-$USE_SUDO apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+$USE_SUDO apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 echo "Docker installation complete!"
-
-
-
-

--- a/packer/ubuntu-server/scripts/provision.sh
+++ b/packer/ubuntu-server/scripts/provision.sh
@@ -12,7 +12,7 @@
 
 # Adjust Docker group permissions.
 groupadd docker
-usermod -aG docker ubuntu
+usermod -aG docker dibbs-user
 newgrp docker
 
 # Set Docker as system service and enable container autostart
@@ -42,7 +42,7 @@ echo "" >> "$DIBBS_SERVICE.env"
 echo 'export $(cat '$HOME/dibbs-vm/"$DIBBS_SERVICE"/*.env' | xargs)' >> "$HOME"/.bashrc
 
 # Gives ubuntu user ownership of the dibbs-vm directory
-chown -R ubuntu:ubuntu "$HOME/dibbs-vm"
+chown -R dibbs-user:dibbs-user "$HOME/dibbs-vm"
 
 # Trigger initial docker compose commands to construct container stack
 docker compose build

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -127,9 +127,9 @@ source "azure-arm" "azure-image" {
 build {
   name = "multi-cloud-build"
   sources = [
-    "source.qemu.iso",
-    "source.amazon-ebs.aws-ami",
-    "source.azure-arm.azure-image"
+    "source.qemu.iso"
+    //"source.amazon-ebs.aws-ami",
+    //"source.azure-arm.azure-image"
   ]
 
   provisioner "shell" {

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -58,7 +58,7 @@ source "qemu" "iso" {
   http_directory   = "http"
   shutdown_command = "echo '${var.ssh_password}' | sudo -S shutdown -P now"
   ssh_username     = "dibbs-user"
-  ssh_password     = var.ssh_password
+  ssh_password     = "${var.ssh_password}"
   ssh_timeout      = "60m"
   machine_type     = "q35"
   cpus             = 2
@@ -141,7 +141,7 @@ build {
       "USE_SUDO=sudo",
       "BUILD_TYPE=azure"
     ]
-    execute_command = "echo ${var.ssh_password} | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    execute_command = "echo '${var.ssh_password}' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
   provisioner "shell" {
@@ -153,7 +153,7 @@ build {
       "USE_SUDO=",
       "BUILD_TYPE=aws"
     ]
-    execute_command = "echo ${var.ssh_password} | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    execute_command = "echo '${var.ssh_password}' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
   provisioner "shell" {

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -128,8 +128,8 @@ build {
   name = "multi-cloud-build"
   sources = [
     "source.qemu.iso"
-    //"source.amazon-ebs.aws-ami",
-    //"source.azure-arm.azure-image"
+    "source.amazon-ebs.aws-ami",
+    "source.azure-arm.azure-image"
   ]
 
   provisioner "shell" {

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -56,9 +56,9 @@ source "qemu" "iso" {
     "boot<enter><wait>"
   ]
   http_directory   = "http"
-  shutdown_command = "echo 'ubuntu' | sudo -S shutdown -P now"
-  ssh_username     = "ubuntu"
-  ssh_password     = "ubuntu"
+  shutdown_command = "echo '${var.ssh_password}' | sudo -S shutdown -P now"
+  ssh_username     = "dibbs-user"
+  ssh_password     = var.ssh_password
   ssh_timeout      = "60m"
   machine_type     = "q35"
   cpus             = 2
@@ -86,7 +86,7 @@ source "amazon-ebs" "aws-ami" {
     most_recent = true
   }
 
-  ssh_username = "ubuntu"
+  ssh_username = "dibbs-user"
 
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
@@ -119,7 +119,7 @@ source "azure-arm" "azure-image" {
   managed_image_name                = "Ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}"
   managed_image_resource_group_name = "skylight-dibbs-vm1"
   os_type                           = "Linux"
-  ssh_username                      = "ubuntu"
+  ssh_username                      = "dibbs-user"
 
 }
 
@@ -141,7 +141,7 @@ build {
       "USE_SUDO=sudo",
       "BUILD_TYPE=azure"
     ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    execute_command = "echo ${var.ssh_password} | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
   provisioner "shell" {
@@ -150,22 +150,10 @@ build {
     environment_vars = [
       "DIBBS_SERVICE=${var.dibbs_service}",
       "DIBBS_VERSION=${var.dibbs_version}",
-      "USE_SUDO=sudo",
+      "USE_SUDO=",
       "BUILD_TYPE=aws"
     ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
-  }
-
-  provisioner "shell" {
-    only   = ["qemu.iso"]
-    script = "scripts/post-install.sh"
-    environment_vars = [
-      "DIBBS_SERVICE=${var.dibbs_service}",
-      "DIBBS_VERSION=${var.dibbs_version}",
-      "USE_SUDO=",
-      "BUILD_TYPE=qemu"
-    ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} bash '{{.Path}}'"
+    execute_command = "echo ${var.ssh_password} | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
   provisioner "shell" {
@@ -176,7 +164,7 @@ build {
       "DIBBS_SERVICE=${var.dibbs_service}",
       "DIBBS_VERSION=${var.dibbs_version}"
     ]
-    execute_command = "echo 'ubuntu' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    execute_command = "echo '${var.ssh_password}' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
   }
 
   provisioner "file" {

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -57,3 +57,8 @@ variable "tenant_id" {
   type        = string
   default     = env("ARM_TENANT_ID")
 }
+
+variable "ssh_password" {
+  description = "SSH password for system configuration"
+  type        = string
+}


### PR DESCRIPTION
To ensure the default VM is secure by default, the following actions have been taken:

* The build script has been updated to generate a cryptographically-secure 24-character password that is added to the virtual machine for the default user login.
* Default user has been switched from `ubuntu` to `dibbs-user` to eliminate lazy brute forcing attacks.
* Default hostname of the system has been updated.
* `fail2ban` has been implemented with default protections on the SSH vector.
* The build pipeline will output the secure password to be provided to STLTs upon completion. An example of this output is below. (A possible future enhancement would mask this password and automatically add it to a secure cloud vault.)

<img width="967" alt="image" src="https://github.com/user-attachments/assets/07acd185-b99a-4570-865c-39dcbd76f36d" />



Additional clean-up:
* Refactor all references to `apt`, as `apt` is unstable when used in a script.
* Noted several locations in the code that must be updated for cloud builds to conform to the new security requirements.
* Disabled cloud builds until the new randomized password and username approaches can be properly added to their provisioning pipelines.