### PR TITLE
feat: add gitsha to build scripts and packer configuration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,15 @@
 
 service=$1
 version=$2
+gitsha=$(git rev-parse --short HEAD)
 cd packer/ubuntu-server/ || exit
 
 # check if the build directory exists
-if [ -d "build/$service-$version" ]; then
+if [ -d "build/$service-$version-$gitsha" ]; then
     echo "Build directory for that version already exists."
     read -rp $'  \e[3m'"Do you want to remove the build directory? (y/n): "$'\e[0m' choice
     if [ "$choice" == "y" ]; then
-        rm -rf "build/$service-$version"
+        rm -rf "build/$service-$version-$gitsha"
     else
         echo "Cannot continue with the build process."
         exit 1
@@ -24,7 +25,7 @@ if [ -z "$service" ] || [ -z "$version" ]; then
 fi
 
 # build machines need to have OpenSSL installed for random password generation.
-if ! command -v openssl &> /dev/null; then
+if ! command -v openssl &>/dev/null; then
     echo "openssl could not be found, exiting..."
     exit 1
 fi
@@ -48,10 +49,10 @@ echo "Password replaced in user-data file."
 packer init .
 
 # validate
-packer validate --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" .
+packer validate --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" --var gitsha="$gitsha" .
 
 # Build the base image
-packer build --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" .
+packer build --var dibbs_service="$service" --var dibbs_version="$version" --var ssh_password="$DIBBS_USER_PASSWORD" --var gitsha="$gitsha" .
 
 echo "Remember, to login, you need to use the password: $DIBBS_USER_PASSWORD"
 

--- a/gcp_image.sh
+++ b/gcp_image.sh
@@ -6,6 +6,7 @@ set -x
 service=$1
 version=$2
 bucket=$3
+gitsha=$(git rev-parse --short HEAD)
 
 if [ -z "$service" ] || [ -z "$version" ]; then
   echo "Remember to log into gcloud before running this script."
@@ -15,8 +16,8 @@ if [ -z "$service" ] || [ -z "$version" ]; then
   exit 1
 fi
 
-if [ -d "packer/ubuntu-server/build/$service-$version/" ]; then
-  cd packer/ubuntu-server/build/$service-$version/ || exit
+if [ -d "packer/ubuntu-server/build/$service-$version-$gitsha/" ]; then
+  cd packer/ubuntu-server/build/$service-$version-$gitsha/ || exit
   echo "Build directory for that version exists, continuing with conversion."
 else
   echo "Build directory for that version does not exist."
@@ -24,19 +25,19 @@ else
 fi
 
 rm disk.raw || true
-rm ubuntu-2404-$service-$version.tar.gz || true
+rm ubuntu-2404-$service-$version-$gitsha.tar.gz || true
 
 # create raw
-cp ubuntu-2404-$service-$version.raw disk.raw
+cp ubuntu-2404-$service-$version-$gitsha.raw disk.raw
 
 # compress raw
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  gtar -czvf ubuntu-2404-$service-$version.tar.gz disk.raw
+  gtar -czvf ubuntu-2404-$service-$version-$gitsha.tar.gz disk.raw
 else
-  tar -czvf ubuntu-2404-$service-$version.tar.gz disk.raw
+  tar -czvf ubuntu-2404-$service-$version-$gitsha.tar.gz disk.raw
 fi
 
 # upload to gcs
-gsutil cp ubuntu-2404-$service-$version.tar.gz gs://$bucket
+gsutil cp ubuntu-2404-$service-$version-$gitsha.tar.gz gs://$bucket
 
 cd - || exit

--- a/packer/ubuntu-server/ubuntu.pkr.hcl
+++ b/packer/ubuntu-server/ubuntu.pkr.hcl
@@ -37,14 +37,14 @@ packer {
 
 
 source "qemu" "raw" {
-  vm_name = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}.raw"
+  vm_name = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}-${var.gitsha}.raw"
   # Uncomment this block to use a basic Ubuntu 24.04 cloud image
   # iso_url              = "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
   iso_url          = "http://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
   iso_checksum     = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
   disk_image       = false
   memory           = 4096
-  output_directory = "build/${var.dibbs_service}-${var.dibbs_version}"
+  output_directory = "build/${var.dibbs_service}-${var.dibbs_version}-${var.gitsha}"
   disk_size        = "24000M"
   disk_interface   = "virtio"
   format           = "raw"
@@ -72,7 +72,7 @@ source "qemu" "raw" {
 
 
 source "amazon-ebs" "aws-ami" {
-  ami_name      = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}"
+  ami_name      = "ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}-${var.gitsha}"
   instance_type = var.aws_instance_type
   region        = var.aws_region
 
@@ -85,7 +85,7 @@ source "amazon-ebs" "aws-ami" {
     owners      = ["099720109477"] # Canonical's official AWS account ID
     most_recent = true
   }
-  
+
   //TODO: CHANGE ME! Change the password to use the random one, too!
   ssh_username = "ubuntu"
 
@@ -97,7 +97,7 @@ source "amazon-ebs" "aws-ami" {
   }
 
   tags = {
-    Name        = "Ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}"
+    Name        = "Ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}-${var.gitsha}"
     Environment = "Dev"
   }
 }
@@ -117,12 +117,12 @@ source "azure-arm" "azure-image" {
   image_publisher                   = "Canonical"
   image_offer                       = "ubuntu-24_04-lts"
   image_sku                         = "server"
-  managed_image_name                = "Ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}"
+  managed_image_name                = "Ubuntu-2404-${var.dibbs_service}-${var.dibbs_version}-${var.gitsha}"
   managed_image_resource_group_name = "skylight-dibbs-vm1"
   os_type                           = "Linux"
 
   //TODO: CHANGE ME! Change the password to use the random one, too!
-  ssh_username                      = "ubuntu"
+  ssh_username = "ubuntu"
 
 }
 
@@ -141,7 +141,7 @@ build {
   }
 
   provisioner "shell" {
-    only   = ["azure-arm.azure-image"]
+    only = ["azure-arm.azure-image"]
     scripts = [
       "scripts/fail2ban.sh",
       "scripts/post-install.sh",
@@ -159,7 +159,7 @@ build {
   }
 
   provisioner "shell" {
-    only   = ["amazon-ebs.aws-ami"]
+    only = ["amazon-ebs.aws-ami"]
     scripts = [
       "scripts/fail2ban.sh",
       "scripts/post-install.sh",
@@ -177,7 +177,7 @@ build {
   }
 
   provisioner "shell" {
-    only   = ["qemu.raw"]
+    only = ["qemu.raw"]
     scripts = [
       "scripts/fail2ban.sh",
       "scripts/provision.sh"

--- a/packer/ubuntu-server/variables.pkr.hcl
+++ b/packer/ubuntu-server/variables.pkr.hcl
@@ -20,6 +20,11 @@ variable "dibbs_version" {
   type        = string
 }
 
+variable "gitsha" {
+  description = "Git SHA of the current commit"
+  type        = string
+}
+
 variable "aws_region" {
   description = "AWS region to build the AMI"
   type        = string
@@ -31,7 +36,6 @@ variable "aws_instance_type" {
   description = "AWS instance type for the build"
   type        = string
   default     = "t3.medium"
-
 }
 
 variable "subscription_id" {


### PR DESCRIPTION
## Changes Proposed

- Incorporates the current git commit's short SHA into build artifacts and directory names. This change applies to build scripts, the GCP image conversion script, and Packer configurations for QEMU, AWS, and Azure.  
- Updates file and directory naming conventions to include the git SHA, ensuring that builds are uniquely identifiable.  

## Additional Information

- The decision to include the git SHA in all naming helps in tracking and versioning of artifacts directly linked to a commit.
This update centralizes the versioning process, minimizing conflicts between builds of different commits.
- Future work may include further automation and integration of git metadata into other parts of the deployment process.

## Testing

- Run the modified build script and verify that the build directory includes the git SHA in its name.
- Check the output file names for both the raw disk image and the compressed tarball in the GCP script.
- Validate that Packer generates images with names that include the git SHA.
- Confirm that the updated OpenSSL check works as expected on your system.