### PR TITLE
Remove validation container and references from eCR Viewer stack.

### DIFF
--- a/dibbs-ecr-viewer/dibbs-orchestration.env
+++ b/dibbs-ecr-viewer/dibbs-orchestration.env
@@ -2,7 +2,6 @@ OTEL_METRICS=none
 OTEL_METRICS_EXPORTER=none
 ECR_VIEWER_URL=http://dibbs-ecr-viewer:3000/ecr-viewer
 INGESTION_URL=http://dibbs-ingestion:8080
-VALIDATION_URL=http://dibbs-validation:8080
 FHIR_CONVERTER_URL=http://dibbs-fhir-converter:8080
 MESSAGE_PARSER_URL=http://dibbs-message-parser:8080
 TRIGGER_CODE_REFERENCE_URL=http://dibbs-trigger-code-reference:8080

--- a/dibbs-ecr-viewer/docker-compose.yml
+++ b/dibbs-ecr-viewer/docker-compose.yml
@@ -18,15 +18,6 @@ services:
     networks:
       - dibbs
 
-  validation:
-    image: ghcr.io/cdcgov/$DIBBS_SERVICE/validation:$DIBBS_VERSION
-    container_name: dibbs-validation
-    restart: always
-    ports:
-      - "8081:8080"
-    networks:
-      - dibbs
-
   fhir-converter:
     image: ghcr.io/cdcgov/$DIBBS_SERVICE/fhir-converter:$DIBBS_VERSION
     container_name: dibbs-fhir-converter


### PR DESCRIPTION
The eCR Viewer team has deprecated the validation container. This PR removes the container from our stack and updates service URL references in the Orchestration container, which should prevent an issue with pulling Docker images that would prevent the stack from starting.

The only affected STLT for this change would be Colorado. If a hot upgrade won't take care of the removal, we will need to issue them a new VM image.