### PR TITLE
Adds env var to wizard for AUTH_SESSION_DURATION_MIN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ docker/dibbs-ecr-viewer/ecr-viewer.bak
 docker/dibbs-query-connectory/.env
 docker/dibbs-query-connectory/query-connectory.wizard.env
 docker/dibbs-query-connectory/query-connectory.env.bak
+
+.idea

--- a/dibbs-ecr-viewer/dibbs-ecr-viewer-wizard.sh.home
+++ b/dibbs-ecr-viewer/dibbs-ecr-viewer-wizard.sh.home
@@ -302,6 +302,7 @@ auth() {
   check_var AUTH_ISSUER
   check_var NEXTAUTH_URL "URL for the eCR Viewer application authentication: http(s)://(DOMAIN||IP:PORT)/ecr-viewer/api/auth/"
   check_var NEXTAUTH_SECRET "Generate a random secret using: openssl rand -base64 32"
+  check_var AUTH_SESSION_DURATION_MIN "The duration, in minutes, before auto-sign out occurs. If no value is set defaults to 30 min"
 }
 
 aws() {


### PR DESCRIPTION
Just what the title says! It mentions a default but the default is set in the viewer itself so it shouldn't be an issue here